### PR TITLE
Replace vCore with NoSQL

### DIFF
--- a/docs/initial_paas_provisioning.md
+++ b/docs/initial_paas_provisioning.md
@@ -1,7 +1,7 @@
 # CosmosAIGraph : Initial PaaS Provisioning
 
 Though the provisioning of Azure PaaS services can be fully automated,
-it is recommended that you deploy **Azure OpenAI** and **Azure Cosmos DB Mongo vCore**
+it is recommended that you deploy **Azure OpenAI** and **Azure Cosmos DB for NoSQL**
 manually in your subscription for this reference application.
 
 The reason for this is that you may already have these resources deployed (i.e - Azure OpenAI)


### PR DESCRIPTION
The intro incorrectly stated that you must provision the Azure Cosmos DB Mongo vCore API instead of the NoSQL one.